### PR TITLE
Add option to hide testing container

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 * Any modules in `requirejs.entries` that end with `-test`.
 * Any modules in `requirejs.entries` that end with `.jshint` (unless JSHint tests are disabled).
 * Sets up `QUnit.notifications` if it is present.
+* Adds 'Hide Testing Container' checkbox

--- a/test-loader.js
+++ b/test-loader.js
@@ -20,3 +20,76 @@ if (QUnit.notifications) {
     }
   });
 }
+
+$(window).on('load', function() {
+  var toolbar              = Ember.$('#qunit-testrunner-toolbar')[0];
+  var hideTestingContainer = document.createElement( "input" );
+
+  hideTestingContainer.type = "checkbox";
+  hideTestingContainer.id   = "hide-testing-container";
+
+  if (QUnit.urlParams.hideTestingContainer === 'true') {
+    hideTestingContainer.checked = true;
+    toggleTestingContainer();
+  }
+
+  hideTestingContainer.addEventListener('click', function(event) {
+    toggleTestingContainer();
+    updateQueryParams(event.target);
+    updateQUnitUrlParams(event.target);
+  });
+
+  toolbar.appendChild(hideTestingContainer);
+
+  var label       = document.createElement('label');
+  label.innerHTML = "Hide Testing Container";
+  label.setAttribute( "for", "hide-testing-container" );
+  label.setAttribute( "title", "Hide Testing Container" );
+  toolbar.appendChild(label);
+
+  function toggleTestingContainer() {
+    var container = Ember.$('#ember-testing-container');
+
+    if (container.css('display') === 'block') {
+      container.css('display', 'none');
+    } else {
+      container.css('display', 'block');
+    }
+  };
+
+  function updateQueryParams(target) {
+    var search = window.location.search
+      .replace(/^\?/, '').split('&')
+      .reduce(function(obj, param) {
+        if (param.length > 0) {
+          param = param.split('=');
+          obj[param[0]] = param[1];
+        }
+        return obj;
+      }, {});
+
+    if (target.checked) {
+      search['hideTestingContainer'] = true;
+    } else {
+      delete search.hideTestingContainer;
+    }
+
+    var newSearch = Object.keys(search).map(function(key) {
+      return "" + key + "=" + search[key];
+    }).join('&');
+
+    if (newSearch.length > 0) {
+      newSearch = "?" + newSearch;
+    }
+
+    window.history.replaceState({}, '', window.location.pathname + newSearch);
+  };
+
+  function updateQUnitUrlParams(target) {
+    if (target.checked) {
+      QUnit.urlParams.hideTestingContainer = true;
+    } else {
+      delete QUnit.urlParams['hideTestingContainer'];
+    }
+  };
+});


### PR DESCRIPTION
Adds "Hide Testing Container" checkbox to the toolbar.

Clicking checkbox does not refresh page. It will hide the container and use pushState to add the "hideTestingContainer" query param to thr URL. If the page is refreshed that query param is read for hiding the testing container. Unchecking the input will properly remove the query param and show the testing container again.
