### PR TITLE
Exclude the project name when requiring files

### DIFF
--- a/test-loader.js
+++ b/test-loader.js
@@ -10,7 +10,7 @@ define("ember-cli/test-loader",
 
     TestLoader.prototype = {
       shouldLoadModule: function(moduleName) {
-        return (moduleName.match(/[-_]test$/));
+        return moduleName.match(/\/.*[-_]test$/);
       },
 
       loadModules: function() {


### PR DESCRIPTION
Ember-cli creates a reexport using [this file](https://github.com/ember-cli/ember-cli/blob/master/lib/utilities/reexport-template.js), so if you have a project named `sample-addon-test` the following file is generated:

```js
define("sample-addon-test", ["sample-addon-test/index", "ember", "exports"], function(__index__, __Ember__, __exports__) {
  "use strict";
  __Ember__["default"].keys(__index__).forEach(function(key){
    __exports__[key] = __index__[key];
  });
});
```

Where `sample-addon-test/index` refers to `sample-addon-test/addon/index.js`. The problem is that TestLoader will load all files ending with [*test](https://github.com/ember-cli/ember-cli-test-loader/blob/master/test-loader.js#L13), which will the above `sample-addon-test` and if the dependency `sample-addon-test/index` is not present, cause an error.

I believe the correct here is to not automatically load the addon index in the tests because TestLoader is just interested in the tests, so I updated `shouldLoadModule ` to do so.