### PR TITLE
Allow additional matchers to be added without monkey patching prototype.

### DIFF
--- a/test-loader.js
+++ b/test-loader.js
@@ -5,7 +5,32 @@ define("ember-cli/test-loader",
   function() {
     "use strict";
 
-    var TestLoader = function() {
+    var moduleIncludeMatchers = [];
+    var moduleExcludeMatchers = [];
+
+    function addModuleIncludeMatcher(fn) {
+      moduleIncludeMatchers.push(fn);
+    };
+
+    function addModuleExcludeMatcher(fn) {
+      moduleExcludeMatchers.push(fn);
+    };
+
+    function checkMatchers(matchers, moduleName) {
+      var matcher;
+
+      for (var i = 0, l = matchers.length; i < l; i++) {
+        matcher = matchers[i];
+
+        if (matcher(moduleName)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    function TestLoader() {
       this._didLogMissingUnsee = false;
     };
 
@@ -18,7 +43,11 @@ define("ember-cli/test-loader",
         var moduleName;
 
         for (moduleName in requirejs.entries) {
-          if (this.shouldLoadModule(moduleName)) {
+          if (checkMatchers(moduleExcludeMatchers, moduleName)) {
+            continue;
+          }
+
+          if (checkMatchers(moduleIncludeMatchers, moduleName) || this.shouldLoadModule(moduleName)) {
             this.require(moduleName);
             this.unsee(moduleName);
           }
@@ -54,8 +83,10 @@ define("ember-cli/test-loader",
     };
 
     return {
-      'default': TestLoader
-    }
+      'default': TestLoader,
+      addModuleIncludeMatcher: addModuleIncludeMatcher,
+      addModuleExcludeMatcher: addModuleExcludeMatcher
+    };
   }
 );
 })();


### PR DESCRIPTION
Currently, `TestLoader.prototype.shouldLoadModule` is monkey patched by ember-cli-qunit / ember-cli-mocha to add their own custom rules for matching modules.

This change allows additional addons to add their own custom matchers (for example adding additional extension types) or to suppress a certain subset of modules (for example JSHint or JSCS tests).