### PR TITLE
Add ability to tweak module loading order.

### DIFF
--- a/test-loader.js
+++ b/test-loader.js
@@ -39,10 +39,17 @@ define("ember-cli/test-loader",
         return (moduleName.match(/[-_]test$/));
       },
 
-      loadModules: function() {
-        var moduleName;
+      listModules: function() {
+        return Object.keys(requirejs.entries);
+      },
 
-        for (moduleName in requirejs.entries) {
+      loadModules: function() {
+        var moduleName, index, length;
+        var moduleNames = this.listModules();
+
+        for (index = 0, length = moduleNames.length; index < length; index++) {
+          moduleName = moduleNames[index];
+
           if (checkMatchers(moduleExcludeMatchers, moduleName)) {
             continue;
           }


### PR DESCRIPTION
This abstracts the listing of modules from the iteration allowing us to:

* tweak/change away from `requirejs.entries` at some point
* an app/addon to tweak the run order of test modules (for example to run JSHint/JSCS tests first)