### PR TITLE
Updated README to use 0.2.2 instead of 1.0.0 during npm updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Within your test suite:
 
   TestLoader.load();
 ```
+
+#
+#
+#
+#
+---
+_**Note:** 1.0.0 will move to package.json from bower.json, but that is not enabled yet. The default ember-cli blueprint specifies 0.2.2 which should definitely not allow 1.0.0. - [[Link](https://github.com/ember-cli/ember-cli-test-loader/issues/19)]_


### PR DESCRIPTION
During automatic update process using [ncu](https://github.com/tjunnone/npm-check-updates), the version gets set to `1.0.0` in `bower.json`, which breaks on running `ember server`. The note will help people figure out what they should be doing till the time `1.0.0` is ready to be used instead of `0.2.2`
