### PR TITLE
Implement listTestModules

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -39,21 +39,34 @@ TestLoader.prototype = {
     return Object.keys(requirejs.entries);
   },
 
-  loadModules: function() {
-    var moduleName, index, length;
+  listTestModules: function(){
     var moduleNames = this.listModules();
+    var testModules = [];
+    var moduleName;
 
-    for (index = 0, length = moduleNames.length; index < length; index++) {
-      moduleName = moduleNames[index];
+    for (var i = 0; i < moduleNames.length; i++) {
+      moduleName = moduleNames[i];
 
       if (checkMatchers(moduleExcludeMatchers, moduleName)) {
         continue;
       }
 
       if (checkMatchers(moduleIncludeMatchers, moduleName) || this.shouldLoadModule(moduleName)) {
-        this.require(moduleName);
-        this.unsee(moduleName);
+        testModules.push(moduleName);
       }
+    }
+
+    return testModules;
+  },
+
+  loadModules: function() {
+    var testModules = this.listTestModules();
+    var testModule;
+
+    for (var i = 0; i < testModules.length; i++) {
+      testModule = testModules[i];
+      this.require(testModule);
+      this.unsee(testModule);
     }
   }
 };


### PR DESCRIPTION
This refactor was to separate logic for identifying modules to load and actually loading them. This enables users to hook into `listTestModules` to modify the array of modules to load, enabling features like test splitting or (maybe) even randomization. Originally discussed in trentmwillis/ember-exam#15.

cc @stefanpenner 