### PR TITLE
Add ember-cli-babel to dependencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/ember-cli/ember-cli-test-loader/issues"
   },
-  "homepage": "https://github.com/ember-cli/ember-cli-test-loader#readme"
+  "homepage": "https://github.com/ember-cli/ember-cli-test-loader#readme",
+  "dependencies": {
+    "ember-cli-babel": "^5.2.1"
+  }
 }


### PR DESCRIPTION
Fixes warning when used with latest version of ember-cli.