### PR TITLE
Update to Babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.1",
   "description": "Test loader for Ember CLI projects.",
   "main": "index.js",
+  "engines": {
+    "node": ">= 4.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -20,6 +23,6 @@
   },
   "homepage": "https://github.com/ember-cli/ember-cli-test-loader#readme",
   "dependencies": {
-    "ember-cli-babel": "^5.2.1"
+    "ember-cli-babel": "^6.0.0-beta.7"
   }
 }


### PR DESCRIPTION
As part of the work for ember-cli@2.13, all "built in" addons are being updated to use ember-cli-babel@6.

Also, bumped the minimum engine version to match ember-cli's version.