### PR TITLE
Drop support for Node 6 and 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Test loader for Ember CLI projects.",
   "main": "index.js",
   "engines": {
-    "node": ">= 4.0"
+    "node": "10.* || >= 12"
   },
   "scripts": {
     "changelog": "lerna-changelog",


### PR DESCRIPTION
because Node 6 has reached its EOL and Node 8 will be by the end of the month